### PR TITLE
Update validUntil date on cpm.sh run

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ will expect to be able to write to both a `/var/metadatafiles` and a `/var/metad
 write to a `/var/www/html/downloads` directory.
 3. Copy the `metadata-start.xml` and `metadata-end.xml` files to `/var/metadatafile`.
 4. Next, copy the contents of the `xmlschema` directory to `/software/xmlschema`.  
-5. Finally, you need to ensure that the PHP-XML and xmllint libraries are installed.
+5. Finally, you need to ensure that the PHP-XML and xmllint libraries are installed as well as the xmlstarlet application.
 
 You should now be able to upload and create a metadata aggregate.  Next steps would be to modify `cpm.sh` to use [xmlsectool](https://wiki.shibboleth.net/confluence/display/SHIB2/XmlSecTool)
 to sign the aggregate before making it available for download.

--- a/cpm.sh
+++ b/cpm.sh
@@ -10,6 +10,7 @@
 #
 # Note: This script requires the existence of var metadata directories for now.
 #
+NEWDATE=$(date +%Y-%m-%dT00:00:00Z -d "14 days")
 
 rm -rf /var/metadatafile/ShibTrain1-metadata.xml
 rm -rf /var/metadatafiles/*
@@ -19,6 +20,7 @@ cp /home/classuser/* /var/metadatafiles/
 cat /var/metadatafile/metadata-start.xml >> /var/metadatafile/ShibTrain1-metadata.xml
 cat /var/metadatafiles/* >> /var/metadatafile/ShibTrain1-metadata.xml
 cat /var/metadatafile/metadata-end.xml >> /var/metadatafile/ShibTrain1-metadata.xml
+xmlstarlet ed --inplace -O -P -N x="urn:oasis:names:tc:SAML:2.0:metadata" -u "//x:EntitiesDescriptor/@validUntil" -v "$NEWDATE" /var/metadatafile/ShibTrain1-metadata.xml
 #cp /var/metadatafile/ShibTrain1-metadata.xml /opt/shibboleth-idp/metadata/
 #cp /var/metadatafile/ShibTrain1-metadata.xml /opt/shibboleth-ds/metadata/
 #cp /var/metadatafile/ShibTrain1-metadata.xml /etc/shibboleth/


### PR DESCRIPTION
This updates the metadata aggregate xml file's validUntil date to 2 weeks out each time cpm.sh is run using xmlstarlet. This negates the need for one to manually edit the date as if date expiration is reached, the file is rejected. Added xmlstarlet requirement to README.